### PR TITLE
Adjust used release for CI

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,7 +17,7 @@ jobs:
   branch: rhel-9-main
   targets:
     centos-stream-9-x86_64:
-        distros: [RHEL-9.4.0-Nightly]
+        distros: [RHEL-9.5.0-Nightly]
   use_internal_tf: True
   skip_build: true
   tf_extra_params:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Updated Packit configuration to use RHEL 9.5.0 Nightly release for CentOS Stream 9 target